### PR TITLE
Tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ primitive-types = "0.8"
 rustc-hex = "2.1"
 faster-hex = "0.5"
 firestorm = "0.4.5"
-
+atomic-take = "1.0"
 
 [build-dependencies]
 neon-build = "0.8.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,24 @@
+use crate::marshalling::*;
+use neon::{prelude::*, result::Throw};
+
+impl<Ok, Err> IntoHandle for Result<Ok, Err>
+where
+    Ok: IntoHandle,
+    Err: IntoError,
+{
+    type Handle = <Ok as IntoHandle>::Handle;
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> JsResult<'c, Self::Handle> {
+        match self {
+            Ok(ok) => ok.into_handle(cx),
+            Err(e) => {
+                let e = e.into_error(cx)?;
+                cx.throw(e)
+            }
+        }
+    }
+}
+
+pub fn throw<'a, S: AsRef<str>, T>(cx: &mut impl Context<'a>, msg: S) -> Result<T, Throw> {
+    let error = cx.error(msg)?;
+    cx.throw(error)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,4 @@
+pub mod errors;
 pub mod marshalling;
 pub(crate) mod prelude;
+pub mod task;

--- a/src/marshalling/codecs.rs
+++ b/src/marshalling/codecs.rs
@@ -61,6 +61,10 @@ impl Decode<str> for Bytes32 {
     }
 }
 
+// This appears like a job for const generics, but I had trouble using
+// the derived values. Eg: String::with_capacity(/* what? */) and [0; N*2]
+// These error right now, which are likely just limitations of the const
+// generics MVP.
 impl Encode for Bytes32 {
     fn encode(&self) -> String {
         profile_method!(encode);

--- a/src/marshalling/handle_impls.rs
+++ b/src/marshalling/handle_impls.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 impl<T: IntoHandle> IntoHandle for Vec<T> {
     type Handle = JsArray;
-    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> JsResult<'c, Self::Handle> {
         let arr = JsArray::new(cx, 0);
         for i in 0..self.len() {
             let value = self[i].into_handle(cx)?;
@@ -51,7 +51,7 @@ impl<T: FromHandle> FromHandle for Vec<T> {
 
 impl<'a, T0: IntoHandle, T1: IntoHandle> IntoHandle for (T0, T1) {
     type Handle = JsArray;
-    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> JsResult<'c, Self::Handle> {
         let arr = JsArray::new(cx, 0);
         let value = self.0.into_handle(cx)?;
         arr.set(cx, 0, value)?;
@@ -63,7 +63,7 @@ impl<'a, T0: IntoHandle, T1: IntoHandle> IntoHandle for (T0, T1) {
 
 impl IntoHandle for String {
     type Handle = JsString;
-    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> JsResult<'c, Self::Handle> {
         Ok(JsString::new(cx, self))
     }
 }
@@ -72,7 +72,7 @@ impl IntoHandle for Vec<u8> {
     // Better would be Uint8Array, but for our use-cases we are turning them
     // into hex strings anyway so we might as well just go straight there.
     type Handle = JsString;
-    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> JsResult<'c, Self::Handle> {
         let hex: String = self.to_hex();
         hex.into_handle(cx)
     }
@@ -83,7 +83,7 @@ where
     T: IntoHandle,
 {
     type Handle = JsValue;
-    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> JsResult<'c, Self::Handle> {
         Ok(match self {
             Some(t) => t.into_handle(cx)?.upcast(),
             None => cx.null().upcast(),
@@ -93,21 +93,21 @@ where
 
 impl IntoHandle for U256 {
     type Handle = JsString;
-    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> JsResult<'c, Self::Handle> {
         self.encode().into_handle(cx)
     }
 }
 
 impl IntoHandle for f64 {
     type Handle = JsNumber;
-    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> JsResult<'c, Self::Handle> {
         Ok(JsNumber::new(cx, *self))
     }
 }
 
 impl IntoHandle for u64 {
     type Handle = JsNumber;
-    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> JsResult<'c, Self::Handle> {
         if *self > 9007199254740991 {
             throw(cx, "Number exceeded limits of f64")
         } else {
@@ -122,7 +122,7 @@ where
 {
     type Handle = JsString;
 
-    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> JsResult<'c, Self::Handle> {
         self.encode().into_handle(cx)
     }
 }
@@ -169,7 +169,7 @@ impl FromHandle for bool {
 
 impl IntoHandle for bool {
     type Handle = JsBoolean;
-    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> JsResult<'c, Self::Handle> {
         Ok(cx.boolean(*self))
     }
 }

--- a/src/marshalling/handle_impls.rs
+++ b/src/marshalling/handle_impls.rs
@@ -7,16 +7,9 @@ use rustc_hex::ToHex as _;
 use secp256k1::SecretKey;
 use std::time::Duration;
 
-impl<'h, T: Value> IntoHandle<'h> for Handle<'h, T> {
-    type Handle = T;
-    fn into_handle(&self, _cx: &mut impl Context<'h>) -> NeonResult<Handle<'h, Self::Handle>> {
-        Ok(*self)
-    }
-}
-
-impl<'h, T: IntoHandle<'h>> IntoHandle<'h> for Vec<T> {
+impl<T: IntoHandle> IntoHandle for Vec<T> {
     type Handle = JsArray;
-    fn into_handle(&self, cx: &mut impl Context<'h>) -> NeonResult<Handle<'h, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
         let arr = JsArray::new(cx, 0);
         for i in 0..self.len() {
             let value = self[i].into_handle(cx)?;
@@ -56,9 +49,9 @@ impl<T: FromHandle> FromHandle for Vec<T> {
     }
 }
 
-impl<'a, T0: IntoHandle<'a>, T1: IntoHandle<'a>> IntoHandle<'a> for (T0, T1) {
+impl<'a, T0: IntoHandle, T1: IntoHandle> IntoHandle for (T0, T1) {
     type Handle = JsArray;
-    fn into_handle(&self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
         let arr = JsArray::new(cx, 0);
         let value = self.0.into_handle(cx)?;
         arr.set(cx, 0, value)?;
@@ -68,29 +61,29 @@ impl<'a, T0: IntoHandle<'a>, T1: IntoHandle<'a>> IntoHandle<'a> for (T0, T1) {
     }
 }
 
-impl<'a> IntoHandle<'a> for String {
+impl IntoHandle for String {
     type Handle = JsString;
-    fn into_handle(&self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
         Ok(JsString::new(cx, self))
     }
 }
 
-impl<'a> IntoHandle<'a> for Vec<u8> {
+impl IntoHandle for Vec<u8> {
     // Better would be Uint8Array, but for our use-cases we are turning them
     // into hex strings anyway so we might as well just go straight there.
     type Handle = JsString;
-    fn into_handle(&self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
         let hex: String = self.to_hex();
         hex.into_handle(cx)
     }
 }
 
-impl<'a, T> IntoHandle<'a> for Option<T>
+impl<T> IntoHandle for Option<T>
 where
-    T: IntoHandle<'a>,
+    T: IntoHandle,
 {
     type Handle = JsValue;
-    fn into_handle(&self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
         Ok(match self {
             Some(t) => t.into_handle(cx)?.upcast(),
             None => cx.null().upcast(),
@@ -98,23 +91,23 @@ where
     }
 }
 
-impl<'a> IntoHandle<'a> for U256 {
+impl IntoHandle for U256 {
     type Handle = JsString;
-    fn into_handle(&self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
         self.encode().into_handle(cx)
     }
 }
 
-impl<'a> IntoHandle<'a> for f64 {
+impl IntoHandle for f64 {
     type Handle = JsNumber;
-    fn into_handle(&self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
         Ok(JsNumber::new(cx, *self))
     }
 }
 
-impl<'a> IntoHandle<'a> for u64 {
+impl IntoHandle for u64 {
     type Handle = JsNumber;
-    fn into_handle(&self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
         if *self > 9007199254740991 {
             throw(cx, "Number exceeded limits of f64")
         } else {
@@ -123,16 +116,13 @@ impl<'a> IntoHandle<'a> for u64 {
     }
 }
 
-impl<'a> IntoHandle<'a> for Bytes32 {
+impl<const N: usize> IntoHandle for [u8; N]
+where
+    [u8; N]: Encode,
+{
     type Handle = JsString;
-    fn into_handle(&self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::Handle>> {
-        self.encode().into_handle(cx)
-    }
-}
 
-impl<'a> IntoHandle<'a> for Address {
-    type Handle = JsString;
-    fn into_handle(&self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
         self.encode().into_handle(cx)
     }
 }
@@ -177,9 +167,9 @@ impl FromHandle for bool {
     }
 }
 
-impl<'a> IntoHandle<'a> for bool {
+impl IntoHandle for bool {
     type Handle = JsBoolean;
-    fn into_handle(&self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::Handle>> {
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>> {
         Ok(cx.boolean(*self))
     }
 }

--- a/src/marshalling/mod.rs
+++ b/src/marshalling/mod.rs
@@ -2,9 +2,9 @@ use neon::{prelude::*, result::Throw};
 pub mod codecs;
 mod handle_impls;
 
-pub trait IntoHandle<'a> {
+pub trait IntoHandle {
     type Handle: Value;
-    fn into_handle(&self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::Handle>>;
+    fn into_handle<'c>(&self, cx: &mut impl Context<'c>) -> NeonResult<Handle<'c, Self::Handle>>;
 }
 
 pub trait FromHandle {

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,51 @@
+use crate::marshalling::{IntoError, IntoHandle};
+use atomic_take::AtomicTake;
+use neon::prelude::*;
+
+struct TaskWrapper<F> {
+    f: AtomicTake<F>,
+}
+
+impl<F> TaskWrapper<F> {
+    pub fn new(f: F) -> Self {
+        Self {
+            f: AtomicTake::new(f),
+        }
+    }
+}
+
+impl<F, Ok, Err> Task for TaskWrapper<F>
+where
+    F: 'static + Send + FnOnce() -> Result<Ok, Err>,
+    Err: 'static + Send + IntoError,
+    Ok: 'static + Send + IntoHandle,
+{
+    type Output = Ok;
+    type Error = Err;
+    type JsEvent = <Ok as IntoHandle>::Handle;
+
+    fn perform(&self) -> Result<Self::Output, Self::Error> {
+        let f = self.f.take().unwrap();
+        f()
+    }
+
+    fn complete(
+        self,
+        mut cx: TaskContext,
+        result: Result<Self::Output, Self::Error>,
+    ) -> JsResult<Self::JsEvent> {
+        result.into_handle(&mut cx)
+    }
+}
+
+/// Runs a function asynchronously then calls
+/// the callback with the result.
+pub fn run_async<'c, F, Ok, Err>(callback: Handle<JsFunction>, f: F)
+where
+    F: 'static + Send + FnOnce() -> Result<Ok, Err>,
+    Err: 'static + Send + IntoError,
+    Ok: 'static + Send + IntoHandle,
+{
+    let task = TaskWrapper::new(f);
+    task.schedule(callback);
+}


### PR DESCRIPTION
This greatly simplifies running tasks asynchronously with neon.

When running async code with neon the first time, I found two different ways to segfault the process (without even using unsafe!). The result was a soup of structs, threading code, locks, and assumptions. This struct soup of dangerous code had to be re-cooked from scratch for each JS API that would run asynchronously.

Now all that is encapsulated in `run_async` (with the innocuous looking but very important segfault side-stepping `impl IntoHandle for Result` helping out to make sure `cx.throw` is used when returning `JsResult::Err` instead of just returning `Err(cx.error(..))`).

Example usage:
```rust
let data: Vec<u8> = cx.arg(0)?;
let callback = cx.arg(1)?;
run_async(callback, move || keccak(&data));
```
It just works and converts the resulting `[u8; 32]` for you to a `JsString` of `"0x000..."`.